### PR TITLE
Crudely closes #7 with one figure per chapter, out of order

### DIFF
--- a/reportGenerator.m
+++ b/reportGenerator.m
@@ -1,48 +1,19 @@
-import mlreportgen.report.*
-surf(peaks);
-rpt = Report('peaks');
-chapter = Chapter();
-chapter.Title = 'reporrtGenFigure Example';
-add(rpt,chapter);
-
-fig = reporrtGenFigure();
-fig.Snapshot.Caption = '3-D shaded surface plot';
-fig.Snapshot.Height = '5in';
-
-add(rpt,fig);
-delete(gcf);
-rptview(rpt);
-%%
+tic
 import mlreportgen.report.*
 import mlreportgen.dom.*
 rpt = Report('peaks');
-
-figure(6)
-reporrtGenFigure = Figure();
-image06 = Image(getSnapshotImage(reporrtGenFigure,rpt));
-image06.Width = '3in';
-image06.Height = [];
-
-figure(7)
-reporrtGenFigure = Figure();
-image07 = Image(getSnapshotImage(reporrtGenFigure,rpt));
-image07.Width = '3in';
-image07.Height = [];
-
-figure(8)
-reporrtGenFigure = Figure();
-image08 = Image(getSnapshotImage(reporrtGenFigure,rpt));
-image08.Width = '3in';
-image08.Height = [];
-
-figure(9)
-reporrtGenFigure = Figure();
-image09 = Image(getSnapshotImage(reporrtGenFigure,rpt));
-image09.Width = '3in';
-image09.Height = [];
-
-t = Table({image06,image07;image08,image09;...
-    'peaks(20)','peaks(40)';'peaks(60)','peaks(80)'});
-add(rpt,t);
+% Cycle through figures
+h = findobj('type','figure');
+for idx=1:numel(h)
+    % Chapter can be reused
+    ch = Chapter();
+    ch.Title = sprintf(['This is the title of chapter',num2str(idx)]);
+    % Chapter can be reused
+    fig = Figure(h(idx).CurrentAxes);
+    add(ch,fig);
+    add(rpt,ch);
+end
+%
 close(rpt);
 rptview(rpt);
+disp(['Generating report of ',num2str(numel(h)),' figures took ',num2str(toc),' seconds'])


### PR DESCRIPTION
Crudely closes #7 with one figure per chapter, out of order. Later you can put them in order, exploit figure names as chapter names, and use table of contents